### PR TITLE
feat: add header components for dashboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "root": true,
   "ignorePatterns": ["dist", "coverage"],
   "parserOptions": {
-    "ecmaVersion": 2020
+    "ecmaVersion": 2020,
+    "sourceType": "module"
   },
   "overrides": [
     {

--- a/angular.json
+++ b/angular.json
@@ -7,7 +7,7 @@
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
-          "style": "sass"
+          "style": "scss"
         },
         "@schematics/angular:application": {
           "strict": true
@@ -26,13 +26,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "sass",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.sass"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -94,23 +89,15 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "sass",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.sass"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "4.28.2",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-prettier": "^4.0.0",
     "jasmine-core": "~3.8.0",
     "karma": "~6.3.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,3 @@
-<router-outlet></router-outlet>
+<router-outlet>
+  <app-header></app-header>
+</router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.sass'],
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
   title = 'exadel-sandbox-fe';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,9 +3,13 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { HeaderComponent } from './components/dashboard/header/header.component';
+import { UserInfoComponent } from './components/dashboard/header/user-info/user-info.component';
+import { AppLogoComponent } from './components/dashboard/header/app-logo/app-logo.component';
+import { UserDropdownMenuComponent } from './components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, HeaderComponent, UserInfoComponent, AppLogoComponent, UserDropdownMenuComponent],
   imports: [BrowserModule, AppRoutingModule],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/components/dashboard/header/app-logo/app-logo.component.html
+++ b/src/app/components/dashboard/header/app-logo/app-logo.component.html
@@ -1,0 +1,3 @@
+<div class="logo--container">
+  <img [src]="logoSource" alt="logo" class="sitelogo" />
+</div>

--- a/src/app/components/dashboard/header/app-logo/app-logo.component.scss
+++ b/src/app/components/dashboard/header/app-logo/app-logo.component.scss
@@ -1,0 +1,8 @@
+.logo--container {
+  height: 100%;
+}
+
+.logo--container > img {
+  height: 100%;
+  cursor: pointer;
+}

--- a/src/app/components/dashboard/header/app-logo/app-logo.component.spec.ts
+++ b/src/app/components/dashboard/header/app-logo/app-logo.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AppLogoComponent } from './app-logo.component';
+
+describe('AppLogoComponent', () => {
+  let component: AppLogoComponent;
+  let fixture: ComponentFixture<AppLogoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AppLogoComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppLogoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/dashboard/header/app-logo/app-logo.component.ts
+++ b/src/app/components/dashboard/header/app-logo/app-logo.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-logo',
+  templateUrl: './app-logo.component.html',
+  styleUrls: ['./app-logo.component.scss'],
+})
+export class AppLogoComponent implements OnInit {
+  logoSource = 'https://bm.ge/uploads/news/5fca2f33d03c0.png';
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/components/dashboard/header/header.component.html
+++ b/src/app/components/dashboard/header/header.component.html
@@ -1,0 +1,5 @@
+<header>
+  <app-logo></app-logo>
+  <app-user-info></app-user-info>
+  <!-- <user-dropdown-menu></user-dropdown-menu> -->
+</header>

--- a/src/app/components/dashboard/header/header.component.scss
+++ b/src/app/components/dashboard/header/header.component.scss
@@ -1,0 +1,9 @@
+header {
+  width: 100%;
+  height: 70px;
+  display: flex;
+  position: relative;
+  justify-content: space-between;
+  padding: 0 10px 0 10px;
+  background: linear-gradient(to right, rgba(64, 190, 238, 255), rgba(64, 190, 238, 255), rgba(254, 254, 254, 255));
+}

--- a/src/app/components/dashboard/header/header.component.spec.ts
+++ b/src/app/components/dashboard/header/header.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HeaderComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/dashboard/header/header.component.ts
+++ b/src/app/components/dashboard/header/header.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.html
+++ b/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.html
@@ -1,0 +1,5 @@
+<div class="dropdown-menu">
+  <ul>
+    <li *ngFor="let item of menuItems"><a href="#">{{item}}</a></li>
+  </ul>
+</div>

--- a/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.scss
+++ b/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.scss
@@ -1,0 +1,4 @@
+.dropdown-menu {
+  position: absolute;
+  display: none;
+}

--- a/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.spec.ts
+++ b/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserDropdownMenuComponent } from './user-dropdown-menu.component';
+
+describe('UserDropdownMenuComponent', () => {
+  let component: UserDropdownMenuComponent;
+  let fixture: ComponentFixture<UserDropdownMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UserDropdownMenuComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserDropdownMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.ts
+++ b/src/app/components/dashboard/header/user-dropdown-menu/user-dropdown-menu.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+import { USER } from '../../../../mock-user-info';
+
+@Component({
+  selector: 'user-dropdown-menu',
+  templateUrl: './user-dropdown-menu.component.html',
+  styleUrls: ['./user-dropdown-menu.component.scss'],
+})
+export class UserDropdownMenuComponent implements OnInit {
+  menuItems = USER.hasAccessTo;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/components/dashboard/header/user-info/user-info.component.html
+++ b/src/app/components/dashboard/header/user-info/user-info.component.html
@@ -1,0 +1,7 @@
+<div class="user--info">
+  <div class="avatar--container">
+    <img [src]="userAvatar" alt="User Avatar" class="user--avatar" />
+  </div>
+  <p>Hello, {{fullName}}</p>
+  <p class="expand--menu">▼</p>
+</div>

--- a/src/app/components/dashboard/header/user-info/user-info.component.scss
+++ b/src/app/components/dashboard/header/user-info/user-info.component.scss
@@ -1,0 +1,26 @@
+.user--info {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  justify-content: space-between;
+  width: 13rem;
+}
+
+.avatar--container {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+  cursor: pointer;
+  background-color: white;
+}
+
+.user--avatar {
+  height: 100%;
+}
+
+.expand--menu {
+  color: green;
+  cursor: pointer;
+}

--- a/src/app/components/dashboard/header/user-info/user-info.component.spec.ts
+++ b/src/app/components/dashboard/header/user-info/user-info.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserInfoComponent } from './user-info.component';
+
+describe('UserInfoComponent', () => {
+  let component: UserInfoComponent;
+  let fixture: ComponentFixture<UserInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UserInfoComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/dashboard/header/user-info/user-info.component.ts
+++ b/src/app/components/dashboard/header/user-info/user-info.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+import { USER } from '../../../../mock-user-info';
+
+@Component({
+  selector: 'app-user-info',
+  templateUrl: './user-info.component.html',
+  styleUrls: ['./user-info.component.scss'],
+})
+export class UserInfoComponent implements OnInit {
+  fullName = `${USER.firstName} ${USER.lastName}`;
+  userAvatar = USER.avatar;
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/mock-user-info.ts
+++ b/src/app/mock-user-info.ts
@@ -1,0 +1,8 @@
+export const USER = {
+  avatar: 'https://cdn.pixabay.com/photo/2013/07/13/10/07/man-156584_960_720.png',
+  id: '0001',
+  firstName: 'John',
+  lastName: 'Doe',
+  status: 'Student',
+  hasAccessTo: ['Account Settings', 'Notifications', 'Messages', 'Events'],
+};

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -1,1 +1,0 @@
-/* You can add global styles to this file, and also import other style files */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,12 @@
+/* You can add global styles to this file, and also import other style files */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+@import url('https://fonts.googleapis.com/css2?family=PT+Sans&display=swap');
+
+body {
+  font-family: 'PT Sans', sans-serif;
+}


### PR DESCRIPTION
1. Created mock user data `mock-user-info.ts` which contains the following information about **logged in** user:  
- Avatar URL;
- ID number;
- First name;
- Last Name
- Status (Mentor / Recruiter / Interviewer / Candidate... .etc)
- What he/she has access on. 

2. Created the following components in `app/components/dashboard/` directory: 
- `header` - container for site logo and user information;
- `app-logo` - website logo (used URL);
- `user-info` - takes information from mock user data and renders user-avatar, full name and dropdown-list button; 
- `dropdown-menu` - Not implemented yet.  Shall render a menu with items/paths  to which the user has an access. 